### PR TITLE
adjust the code on unity_vision's API changes

### DIFF
--- a/unity_cv_datasetvisualizer/setup.py
+++ b/unity_cv_datasetvisualizer/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="unity-cv-datasetvisualizer",
-    version="0.0.1",
+    version="0.0.2",
     author="Unity Technologies",
     description="This Python based tool allows you to visualize datasets created using Unity Computer Vision tools.",
     long_description=long_description,


### PR DESCRIPTION
1. adjust the code on sequence_path.
since unity_vision's API changed, now solo.sequence_path only give the pattern of the sequence path, e.g. dataset\\solo_21/*sequence.0
So added the function to get the exact sequence path when given the sequence path pattern
2. bump up version