### PR TITLE
Update README.md for internal users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ Unity Computer Vision team's python-based Dataset Visualizer provides an easy wa
   <img width="100%" src="datasetvisualizer/docs/showcase-5-labelers.gif" />
 </div>
 
+---
+**For Unity Internal Users Only**
+
+This application only supports Python 3.7, and the installation process is the following (needs to be under Unity VPN):
+1. create a virtual environment with python 3.7
+```bash
+conda create -n dv_env python==3.7
+conda activate dv_env
+```
+2. Install the application by using the following command
+```bash
+pip install unity-cv-datasetvisualizer --extra-index-url=https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/unity-pypi-local/simple/
+```
+3. To open the visualizer
+```bash
+datasetvisualizer -s
+```
+---
 ## Requirements
 
 * Windows 10 or OSX
@@ -33,7 +51,7 @@ We recommend using a virtual environment to install and run the app. One way to 
 * Create a virtual environment named `dv_env` using Conda, and activate it (use `3.7` or `3.8` for `<python_version>`):
 
 ```bash
-conda create -n dv_env python=<python_version>
+conda create -n dv_env python==<python_version>
 conda activate dv_env
 ```
 **Step 2:** Install application

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Unity Computer Vision team's python-based Dataset Visualizer provides an easy wa
 
 ### Internal version
 
-* Windows 10 or macOS **(Both Intel and Apple M1)**
+* Windows 10 or macOS **(Not support Apple M1)**
 * Chrome, Firefox, or Safari 14 and newer (Older versions of Safari are not supported)
-* Python 3.7 **only**
+* Python 3.7 or 3.8. **Note that this application is not compatible with Python 3.9.**
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Unity Computer Vision team's python-based Dataset Visualizer provides an easy wa
 **For Unity Internal Users Only**
 
 This application only supports Python 3.7, and the installation process is the following (needs to be under Unity VPN):
+
+(For Users with Mac M1 Chip, can follow this [article](https://diewland.medium.com/how-to-install-python-3-7-on-macbook-m1-87c5b0fcb3b5) to install Python 3.7)
 1. create a virtual environment with python 3.7
 ```bash
 conda create -n dv_env python==3.7

--- a/README.md
+++ b/README.md
@@ -12,37 +12,27 @@ Unity Computer Vision team's python-based Dataset Visualizer provides an easy wa
   <img width="100%" src="datasetvisualizer/docs/showcase-5-labelers.gif" />
 </div>
 
----
-**For Unity Internal Users Only**
-
-This application only supports Python 3.7, and the installation process is the following (needs to be under Unity VPN):
-
-(For Users with Mac M1 Chip, can follow this [article](https://diewland.medium.com/how-to-install-python-3-7-on-macbook-m1-87c5b0fcb3b5) to install Python 3.7)
-1. create a virtual environment with python 3.7
-```bash
-conda create -n dv_env python==3.7
-conda activate dv_env
-```
-2. Install the application by using the following command
-```bash
-pip install unity-cv-datasetvisualizer --extra-index-url=https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/unity-pypi-local/simple/
-```
-3. To open the visualizer
-```bash
-datasetvisualizer -s
-```
----
 ## Requirements
 
-* Windows 10 or OSX
+### Public version
+
+* Windows 10 or macOS **(Intel based only)**
 * Chrome, Firefox, or Safari 14 and newer (Older versions of Safari are not supported)
 * Python 3.7 or 3.8. **Note that this application is not compatible with Python 3.9.**
+
+### Internal version
+
+* Windows 10 or macOS **(Both Intel and Apple M1)**
+* Chrome, Firefox, or Safari 14 and newer (Older versions of Safari are not supported)
+* Python 3.7 **only**
+
 
 ## Installation
 
 We recommend using a virtual environment to install and run the app. One way to achieve this is using Conda.
 
-**Step 1:** Create a virtual environment (skip to step 2 if you are setting up a virtual environment using other methods)
+### Step 1 
+Create a virtual environment (skip to step 2 if you are setting up a virtual environment using other methods)
 
 * Install Conda if you do not already have it installed on your computer. We recommend [Miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
@@ -50,19 +40,29 @@ We recommend using a virtual environment to install and run the app. One way to 
   * On Mac OS, open a new terminal window.
   * On Windows, you will need to open either Anaconda Prompt or Anaconda Powershell Prompt. These can be found in the Start menu.
 
-* Create a virtual environment named `dv_env` using Conda, and activate it (use `3.7` or `3.8` for `<python_version>`):
+* Create a virtual environment named `dv_env` using Conda, and activate it:
 
 ```bash
 conda create -n dv_env python==<python_version>
 conda activate dv_env
 ```
-**Step 2:** Install application
+### Step 2
 
-Use the following command to install the visualizer.
+Use the following commands to install the visualizer.
+
+***Public version***
 
 ```bash
 pip install unity-cv-datasetvisualizer
 ```
+***Internal version: (requires a connection to the Unity VPN)***
+
+```bash
+pip install unity-cv-datasetvisualizer --extra-index-url=https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/unity-pypi-local/simple/
+```
+
+**Notes**
+> :information_source: For Apple M1 based computers, you can follow this [article](https://diewland.medium.com/how-to-install-python-3-7-on-macbook-m1-87c5b0fcb3b5) to install Python 3.7. Note that the M1 architecture is only supported in the internal version of the app.
 
 > :information_source: On Windows, if you get an error about the system not being able to create a process when running the install command, make sure you have the latest version of Conda installed. Then create a new environment with a new name, and try the install command again. If the error persists, try leaving the Conda virtual environment using `conda deactivate` and running the command outside of any virtual environment.
 


### PR DESCRIPTION
Since the majority of our package users are internal users, and the workflow to install the internal pypi version of the package is different from the public one, I think it will be helpful to add a section in the instruction "for internal users only".

And the reason it only supports 3.7 for the internal version of package now is that we upgraded PySide2 to Pyside6, which would support Mac with M1 chip, but PySide6 along with some other packages will have an issue on Python 3.8. so for internal usage the package, it only supports python 3.7 now.